### PR TITLE
Jofinn/fix session id crash

### DIFF
--- a/TestURLs.json
+++ b/TestURLs.json
@@ -1,0 +1,8 @@
+{
+  "TestURLs": 
+  [
+    "https://apps.powerapps.com/play/{appId}?tenantId={tenantId}&__PATestCaseId={testCaseId}",
+    "https://apps.powerapps.com/play/{appId}?tenantId={tenantId}&__PATestCaseId={testCaseId}",
+    "https://apps.powerapps.com/play/{appId}?tenantId={tenantId}&__PATestCaseId={testCaseId}"
+  ]
+}

--- a/TestURLs.json
+++ b/TestURLs.json
@@ -1,8 +1,0 @@
-{
-  "TestURLs": 
-  [
-    "https://apps.powerapps.com/play/{appId}?tenantId={tenantId}&__PATestCaseId={testCaseId}",
-    "https://apps.powerapps.com/play/{appId}?tenantId={tenantId}&__PATestCaseId={testCaseId}",
-    "https://apps.powerapps.com/play/{appId}?tenantId={tenantId}&__PATestCaseId={testCaseId}"
-  ]
-}


### PR DESCRIPTION
1. Move the fetching of sessionId to disrupt a race condition where we get intermittent failures (exceptions) trying to access Core scripts. 
2. Wrap the fetch in try/catch so that even if it fails it will still execute tests, it just won't report sessionId. If we see a lot of reports of test results with no session Id's we can revisit to look for a better solution/placement of the code.